### PR TITLE
Dramatic speedup in operations

### DIFF
--- a/lib/spell_check.ex
+++ b/lib/spell_check.ex
@@ -1,5 +1,11 @@
 defmodule SpellCheck do
+
+  @chars ?a..?z |> Enum.to_list |> Enum.map(&([ &1 ]))
+  @empty_set MapSet.new()
+
   @word_frequency WordFrequency.words
+  @word_keys @word_frequency |> Map.keys |> MapSet.new
+
   @total @word_frequency |> Map.values |> Enum.sum
 
   def probability(word, N \\ @total) do
@@ -14,28 +20,35 @@ defmodule SpellCheck do
 
   def candidates(word) do
     cond do
-      (words = known([word])) != MapSet.new -> words
-      (words = (word |> edits1 |> MapSet.to_list |> known)) != MapSet.new -> words
-      (words = (word |> edits2 |> MapSet.to_list |> known)) != MapSet.new -> words
+      (words = known(MapSet.put(@empty_set, word)) != @empty_set -> words
+      (words = (word |> edits1 |> known)) != @empty_set -> words
+      (words = (word |> edits2 |> known)) != @empty_set -> words
       true -> [word]
     end
   end
 
   def known(words) do
-    (for w <- words, ^w <- Map.keys(@word_frequency), do: w)
-    |> MapSet.new
+    MapSet.intersection(words, @word_keys)
   end
 
   def edits1(word) do
     splits = for i <- 0..String.length(word), do: String.split_at(word, i)
     deletes = for {left, right} <- splits, right != "", do: left <> String.slice(right, 1, :infinity)
     transposes = for {left, right} <- splits, String.length(right) > 1, do: left <> String.at(right, 1) <> String.at(right, 0) <> String.slice(right, 2, :infinity)
-    replaces = for {left, right} <- splits, char <- ?a..?z |> Enum.to_list, right != "", do: left <> ([char] |> to_string) <> String.slice(right, 1, :infinity)
-    inserts = for {left, right} <- splits, char <- ?a..?z |> Enum.to_list, do: left <> ([char] |> to_string) <> right
-    MapSet.new(deletes ++ transposes ++ replaces ++ inserts)
+    replaces = for {left, right} <- splits, char <- @chars, right != "", do: left <> (char |> to_string) <> String.slice(right, 1, :infinity)
+    inserts = for {left, right} <- splits, char <- @chars, do: left <> (char |> to_string) <> right
+
+    mapset = MapSet.new(deletes)
+
+    mapset = MapSet.union(mapset, MapSet.new(transposes))
+    mapset = MapSet.union(mapset, MapSet.new(replaces))
+    mapset = MapSet.union(mapset, MapSet.new(inserts))
+
+    mapset
   end
 
   def edits2(word) do
     for e1 <- edits1(word), e2 <- edits1(e1), into: MapSet.new, do: e2
   end
+
 end


### PR DESCRIPTION
I'm not sure that the behaviour is 100% the same so please check it, but this takes 2s on my machine vs ~5 minutes and the tests still pass.

```
zackehh:/tmp/spell_check$ date && time mix test
Thu 15 Sep 2016 23:16:43 BST
Excluding tags: [:pending]


SpellCheckTest
  * test Word Frequency (skipped)
  * test replace 2 (1918.4ms)
  * test replace 1 (skipped)
  * test the truth (skipped)
  * test insert (skipped)
  * test replace (skipped)


Finished in 2.0 seconds
6 tests, 0 failures, 5 skipped

Randomized with seed 377808

real    0m2.709s
user    0m2.443s
sys 0m0.421s
```
